### PR TITLE
Option to specify initial REPL namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,17 +62,18 @@ Trenchman does not have `readline` support at this time. If you want to use feat
 usage: trench [<flags>]
 
 Flags:
-      --help            Show context-sensitive help (also try --help-long and --help-man).
-  -p, --port=PORT       Connect to the specified port.
-      --port-file=FILE  Specify port file that specifies port to connect to. Defaults to .nrepl-port.
-  -P, --protocol=nrepl  Use the specified protocol. Possible values: n[repl], p[repl]. Defaults to nrepl.
+      --help               Show context-sensitive help (also try --help-long and --help-man).
+  -p, --port=PORT          Connect to the specified port.
+      --port-file=FILE     Specify port file that specifies port to connect to. Defaults to .nrepl-port.
+  -P, --protocol=nrepl     Use the specified protocol. Possible values: n[repl], p[repl]. Defaults to nrepl.
   -s, --server=[(nrepl|prepl)://]host[:port]
-                        Connect to the specified URL (e.g. prepl://127.0.0.1:5555).
-  -e, --eval=EXPR       Evaluate an expression.
-  -f, --file=FILE       Evaluate a file.
-  -m, --main=NAMESPACE  Call the -main function for a namespace.
-  -C, --color=auto      When to use colors. Possible values: always, auto, none. Defaults to auto.
-      --version         Show application version.
+                           Connect to the specified URL (e.g. prepl://127.0.0.1:5555).
+  -e, --eval=EXPR          Evaluate an expression.
+  -f, --file=FILE          Evaluate a file.
+  -m, --main=NAMESPACE     Call the -main function for a namespace.
+      --init-ns=NAMESPACE  Initialize REPL with the specified namespace. Defaults to "user".
+  -C, --color=auto         When to use colors. Possible values: always, auto, none. Defaults to auto.
+      --version            Show application version.
 ```
 
 ### Connecting to a server

--- a/cmd/trench/helper.go
+++ b/cmd/trench/helper.go
@@ -42,11 +42,12 @@ func readPortFromFile(protocol, portFile string) (int, bool, error) {
 	return port, false, nil
 }
 
-func (h setupHelper) nReplFactory(host string, port int) func(client.OutputHandler) client.Client {
+func (h setupHelper) nReplFactory(host string, port int, initNS string) func(client.OutputHandler) client.Client {
 	return func(outHandler client.OutputHandler) client.Client {
 		c, err := nrepl.NewClient(&nrepl.Opts{
 			Host:          host,
 			Port:          port,
+			InitNS:        initNS,
 			OutputHandler: outHandler,
 			ErrorHandler:  h.errHandler,
 		})
@@ -57,11 +58,12 @@ func (h setupHelper) nReplFactory(host string, port int) func(client.OutputHandl
 	}
 }
 
-func (h setupHelper) pReplFactory(host string, port int) func(client.OutputHandler) client.Client {
+func (h setupHelper) pReplFactory(host string, port int, initNS string) func(client.OutputHandler) client.Client {
 	return func(outHandler client.OutputHandler) client.Client {
 		c, err := prepl.NewClient(&prepl.Opts{
 			Host:          host,
 			Port:          port,
+			InitNS:        initNS,
 			OutputHandler: outHandler,
 			ErrorHandler:  h.errHandler,
 		})
@@ -72,16 +74,16 @@ func (h setupHelper) pReplFactory(host string, port int) func(client.OutputHandl
 	}
 }
 
-func (h setupHelper) setupRepl(protocol string, host string, port int, opts *repl.Opts) *repl.Repl {
+func (h setupHelper) setupRepl(protocol string, host string, port int, initNS string, opts *repl.Opts) *repl.Repl {
 	opts.In = os.Stdin
 	opts.Out = os.Stdout
 	opts.Err = os.Stderr
 	opts.ErrHandler = h.errHandler
 	var factory func(client.OutputHandler) client.Client
 	if protocol == "nrepl" {
-		factory = h.nReplFactory(host, port)
+		factory = h.nReplFactory(host, port, initNS)
 	} else {
-		factory = h.pReplFactory(host, port)
+		factory = h.pReplFactory(host, port, initNS)
 	}
 	return repl.NewRepl(opts, factory)
 }

--- a/cmd/trench/main.go
+++ b/cmd/trench/main.go
@@ -28,6 +28,7 @@ type cmdArgs struct {
 	eval        *string
 	file        *string
 	mainNS      *string
+	initNS      *string
 	colorOption *string
 }
 
@@ -55,6 +56,7 @@ var args = cmdArgs{
 	eval:        kingpin.Flag("eval", "Evaluate an expression.").Short('e').PlaceHolder("EXPR").String(),
 	file:        kingpin.Flag("file", "Evaluate a file.").Short('f').String(),
 	mainNS:      kingpin.Flag("main", "Call the -main function for a namespace.").Short('m').PlaceHolder("NAMESPACE").String(),
+	initNS:      kingpin.Flag("init-ns", "Initialize REPL with the specified namespace. Defaults to \"user\".").PlaceHolder("NAMESPACE").String(),
 	colorOption: kingpin.Flag("color", "When to use colors. Possible values: always, auto, none. Defaults to auto.").Default(COLOR_AUTO).Short('C').Enum(COLOR_NONE, COLOR_AUTO, COLOR_ALWAYS),
 }
 
@@ -82,13 +84,14 @@ func main() {
 	helper := setupHelper{errHandler}
 	protocol, host, port := helper.arbitrateServerInfo(&args)
 	filename := strings.TrimSpace(*args.file)
+	initNS := strings.TrimSpace(*args.initNS)
 	mainNS := strings.TrimSpace(*args.mainNS)
 	code := strings.TrimSpace(*args.eval)
 	opts := &repl.Opts{
 		Printer:  printer,
 		HidesNil: filename != "" || mainNS != "" || code != "",
 	}
-	repl := helper.setupRepl(protocol, host, port, opts)
+	repl := helper.setupRepl(protocol, host, port, initNS, opts)
 	defer repl.Close()
 
 	if filename != "" {

--- a/nrepl/client.go
+++ b/nrepl/client.go
@@ -30,6 +30,7 @@ type (
 	Opts struct {
 		Host          string
 		Port          int
+		InitNS        string
 		Oneshot       bool
 		OutputHandler client.OutputHandler
 		ErrorHandler  client.ErrorHandler
@@ -39,10 +40,14 @@ type (
 )
 
 func NewClient(opts *Opts) (*Client, error) {
+	initNS := opts.InitNS
+	if initNS == "" {
+		initNS = "user"
+	}
 	c := &Client{
 		outputHandler: opts.OutputHandler,
 		errHandler:    opts.ErrorHandler,
-		ns:            "user",
+		ns:            initNS,
 		done:          make(chan struct{}),
 		pending:       map[string]chan client.EvalResult{},
 		idGenerator:   opts.idGenerator,

--- a/prepl/prepl.go
+++ b/prepl/prepl.go
@@ -74,8 +74,11 @@ func NewClient(opts *Opts) (*Client, error) {
 		return nil, err
 	}
 	if initNS != "user" {
-		msg := fmt.Sprintf("(do (require '%s) (in-ns '%s))", initNS, initNS)
+		msg := fmt.Sprintf("(require '%s)\n(in-ns '%s)\n", initNS, initNS)
 		if err := c.Send(msg); err != nil {
+			return nil, err
+		}
+		if _, err := c.Recv(); err != nil {
 			return nil, err
 		}
 		if _, err := c.Recv(); err != nil {


### PR DESCRIPTION
This PR adds the `--init-ns` option like the following:

```sh
$ ./trench -s prepl://localhost:5555 --init-ns clojure.string
clojure.string=> (upper-case "foo")
"FOO"
clojure.string=>
```

Note that the prelude message for prepl must be:

```clojure
(require '<namespace>)
(in-ns '<namespace>)
```

instead of:

```clojure
(do (require '<namespace>) (in-ns '<namespace>))
```

because ClojureScript does not accept the latter as a valid form.