### PR TITLE
Delimiting prepl prelude messages with newline

### DIFF
--- a/prepl/prepl.go
+++ b/prepl/prepl.go
@@ -67,7 +67,7 @@ func NewClient(opts *Opts) (*Client, error) {
 		ns:            initNS,
 		done:          make(chan struct{}),
 	}
-	if err := c.Send("(set! *print-namespace-maps* false)"); err != nil {
+	if err := c.Send("(set! *print-namespace-maps* false)\n"); err != nil {
 		return nil, err
 	}
 	if _, err := c.Recv(); err != nil {

--- a/prepl/prepl_test.go
+++ b/prepl/prepl_test.go
@@ -11,7 +11,7 @@ import (
 func setupMock(steps []client.Step) *client.MockServer {
 	s := make([]client.Step, 1, len(steps)+1)
 	s[0] = client.Step{
-		Expected:  "(set! *print-namespace-maps* false)",
+		Expected:  "(set! *print-namespace-maps* false)\n",
 		Responses: []string{`{:tag :ret, :val "nil"}`},
 	}
 	s = append(s, steps...)


### PR DESCRIPTION
The current implementation of ClojureScript's standard prepl server cannot correctly accept multiple consecutive forms sent without delimiters in between, as shown below:

```clojure
(set! *print-namespace-maps* false)(require 'clojure.string)(in-ns 'clojure.string)
```

This PR adds an extra newline to the end of the prepl prelude message `(set! *print-namespace-maps* false)` to work around the issue for some cases.