### PR TITLE
Pass command-line args to -main

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Trenchman does not have `readline` support at this time. If you want to use feat
 ## Usage
 
 ```
-usage: trench [<flags>]
+usage: trench [<flags>] [<args>...]
 
 Flags:
       --help               Show context-sensitive help (also try --help-long and --help-man).
@@ -75,6 +75,9 @@ Flags:
       --init-ns=NAMESPACE  Initialize REPL with the specified namespace. Defaults to "user".
   -C, --color=auto         When to use colors. Possible values: always, auto, none. Defaults to auto.
       --version            Show application version.
+
+Args:
+  [<args>]  Arguments to pass to -main. These will be ignored unless -m is specified.
 ```
 
 ### Connecting to a server

--- a/cmd/trench/main.go
+++ b/cmd/trench/main.go
@@ -61,7 +61,7 @@ var args = cmdArgs{
 	mainNS:      kingpin.Flag("main", "Call the -main function for a namespace.").Short('m').PlaceHolder("NAMESPACE").String(),
 	initNS:      kingpin.Flag("init-ns", "Initialize REPL with the specified namespace. Defaults to \"user\".").PlaceHolder("NAMESPACE").String(),
 	colorOption: kingpin.Flag("color", "When to use colors. Possible values: always, auto, none. Defaults to auto.").Default(COLOR_AUTO).Short('C').Enum(COLOR_NONE, COLOR_AUTO, COLOR_ALWAYS),
-	args:        kingpin.Arg("args", "Arguments to pass to -main.").Strings(),
+	args:        kingpin.Arg("args", "Arguments to pass to -main. These will be ignored unless -m is specified.").Strings(),
 }
 
 func colorized(colorOption string) bool {

--- a/cmd/trench/main.go
+++ b/cmd/trench/main.go
@@ -85,7 +85,7 @@ func buildMainInvocation(mainNS string, args []string) string {
 		quotedArgs = append(quotedArgs, fmt.Sprintf("%q", arg))
 	}
 	argStr := strings.Join(quotedArgs, " ")
-	return fmt.Sprintf("(do (require '%s) (%s/-main %s))", mainNS, mainNS, argStr)
+	return fmt.Sprintf("(do (require '%s) (%s/-main %s) nil)", mainNS, mainNS, argStr)
 }
 
 func main() {

--- a/cmd/trench/main.go
+++ b/cmd/trench/main.go
@@ -31,6 +31,7 @@ type cmdArgs struct {
 	mainNS      *string
 	initNS      *string
 	colorOption *string
+	args        *[]string
 }
 
 type errorHandler struct {
@@ -60,6 +61,7 @@ var args = cmdArgs{
 	mainNS:      kingpin.Flag("main", "Call the -main function for a namespace.").Short('m').PlaceHolder("NAMESPACE").String(),
 	initNS:      kingpin.Flag("init-ns", "Initialize REPL with the specified namespace. Defaults to \"user\".").PlaceHolder("NAMESPACE").String(),
 	colorOption: kingpin.Flag("color", "When to use colors. Possible values: always, auto, none. Defaults to auto.").Default(COLOR_AUTO).Short('C').Enum(COLOR_NONE, COLOR_AUTO, COLOR_ALWAYS),
+	args:        kingpin.Arg("args", "Arguments to pass to -main.").Strings(),
 }
 
 func colorized(colorOption string) bool {
@@ -75,6 +77,15 @@ func colorized(colorOption string) bool {
 		}
 	}
 	return false
+}
+
+func buildMainInvocation(mainNS string, args []string) string {
+	quotedArgs := []string{}
+	for _, arg := range args {
+		quotedArgs = append(quotedArgs, fmt.Sprintf("%q", arg))
+	}
+	argStr := strings.Join(quotedArgs, " ")
+	return fmt.Sprintf("(do (require '%s) (%s/-main %s))", mainNS, mainNS, argStr)
 }
 
 func main() {
@@ -105,7 +116,7 @@ func main() {
 		return
 	}
 	if mainNS != "" {
-		repl.Eval(fmt.Sprintf("(do (require '%s) (%s/-main))", mainNS, mainNS))
+		repl.Eval(buildMainInvocation(mainNS, *args.args))
 		return
 	}
 	if code != "" {


### PR DESCRIPTION
Currently, there is no way to pass command-line args to the `-main` function when `-m` is specified.
This PR provides the way to do that:

```sh
$ cat src/arith.clj
(ns arith)

(defn -main [op & args]
  (if-let [op' (case op "add" + "sub" - nil)]
    (let [args' (map read-string args)]
      (prn (apply op' args')))
    (throw (ex-info (str "Unknown op: " op) {}))))
$ trench -m arith add 1 2
3
$ trench -m arith sub 3 1
2
$
```

Also, `--` can be used as a separator to distinguish arguments to pass to `-main` from the ones that should be passed directly to Trenchman:

```sh
$ trench -m arith -- add 1 2
```
