### PR TITLE
Support nrepl+unix connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Flags:
   -p, --port=PORT               Connect to the specified port.
       --port-file=FILE          Specify port file that specifies port to connect to. Defaults to .nrepl-port.
   -P, --protocol=nrepl          Use the specified protocol. Possible values: n[repl], p[repl]. Defaults to nrepl.
-  -s, --server=[(nrepl|prepl)://]host[:port]
-                                Connect to the specified URL (e.g. prepl://127.0.0.1:5555).
+  -s, --server=[(nrepl|prepl)://]host[:port]|nrepl+unix:path
+                                Connect to the specified URL (e.g. prepl://127.0.0.1:5555, nrepl+unix:/foo/bar.socket).
       --retry-timeout=DURATION  Timeout after which retries are aborted. By default, Trenchman never retries connection.
       --retry-interval=1s       Interval between retries when connecting to the server.
   -i, --init=FILE               Load a file before execution.
@@ -89,6 +89,14 @@ One way to connect to a running server using Trenchman is to specify the server 
 
 ```sh
 $ trench -s nrepl://localhost:12345
+```
+
+Trenchman 0.3.0+ can also establish an nREPL connection via UNIX domain socket.
+To do so, specify the `--server` option with the `nrepl+unix:` scheme
+followed by the address path of the socket:
+
+```sh
+$ trench -s nrepl+unix:/foo/bar.socket
 ```
 
 In addition to nREPL, Trenchman supports the prepl protocol as well.

--- a/client/conn_builder.go
+++ b/client/conn_builder.go
@@ -15,8 +15,16 @@ type TCPConnBuilder struct {
 	Port int
 }
 
-func (conn *TCPConnBuilder) Connect() (net.Conn, error) {
-	return net.Dial("tcp", fmt.Sprintf("%s:%d", conn.Host, conn.Port))
+type UnixConnBuilder struct {
+	Path string
+}
+
+func (builder *TCPConnBuilder) Connect() (net.Conn, error) {
+	return net.Dial("tcp", fmt.Sprintf("%s:%d", builder.Host, builder.Port))
+}
+
+func (builder *UnixConnBuilder) Connect() (net.Conn, error) {
+	return net.Dial("unix", builder.Path)
 }
 
 type ConnBuilderFunc func() (net.Conn, error)

--- a/cmd/trench/helper.go
+++ b/cmd/trench/helper.go
@@ -13,7 +13,8 @@ import (
 	"github.com/athos/trenchman/repl"
 )
 
-var urlRegex = regexp.MustCompile(`(?:(nrepl|prepl)://)?([^:]+)(?::(\d+))?`)
+var urlRegex = regexp.MustCompile(`^(?:(nrepl|prepl)://)?([^:]+)(?::(\d+))?$`)
+var unixUrlRegex = regexp.MustCompile(`^nrepl\+unix:(.+)$`)
 
 type setupHelper struct {
 	errHandler client.ErrorHandler
@@ -86,31 +87,41 @@ func (h setupHelper) setupRepl(protocol string, connBuilder client.ConnBuilder, 
 	return repl.NewRepl(opts, factory)
 }
 
-func (h setupHelper) resolveConnection(args *cmdArgs) (protocol string, connBuilder client.ConnBuilder) {
-	server := *args.server
-	var host string
-	var port int
-	if server != "" {
-		match := urlRegex.FindStringSubmatch(server)
-		if match == nil {
-			err := errors.New("bad url specified to -s option: " + server)
-			h.errHandler.HandleErr(err)
-			return
-		}
+func (h setupHelper) parseServerUrl(url string) (protocol string, dest string, port int, err error) {
+	if match := urlRegex.FindStringSubmatch(url); match != nil {
 		protocol = match[1]
-		host = match[2]
+		dest = match[2]
 		if match[3] != "" {
 			port, _ = strconv.Atoi(match[3])
 		}
+		return
 	}
+	if match := unixUrlRegex.FindStringSubmatch(url); match != nil {
+		protocol = "nrepl+unix"
+		dest = match[1]
+		return
+	}
+	err = errors.New("bad url specified to -s option: " + url)
+	return
+}
+
+func (h setupHelper) resolveProtocol(protocol string, args *cmdArgs) (ret string, unixSocket bool) {
 	if protocol == "" {
-		switch *args.protocol {
-		case "n", "nrepl":
-			protocol = "nrepl"
-		case "p", "prepl":
-			protocol = "prepl"
-		}
+		protocol = *args.protocol
 	}
+	switch protocol {
+	case "n", "nrepl":
+		ret = "nrepl"
+	case "nrepl+unix":
+		ret = "nrepl"
+		unixSocket = true
+	case "p", "prepl":
+		ret = "prepl"
+	}
+	return
+}
+
+func (h setupHelper) resolvePort(protocol string, port int, args *cmdArgs) (int, error) {
 	if port == 0 && *args.port != 0 {
 		port = *args.port
 	}
@@ -122,12 +133,35 @@ func (h setupHelper) resolveConnection(args *cmdArgs) (protocol string, connBuil
 			} else {
 				err = errors.New("port must be specified with -p or -s")
 			}
-			h.errHandler.HandleErr(err)
-			return
+			return 0, err
 		}
 		port = p
 	}
-	connBuilder = &client.TCPConnBuilder{Host: host, Port: port}
+	return port, nil
+}
+
+func (h setupHelper) resolveConnection(args *cmdArgs) (protocol string, connBuilder client.ConnBuilder) {
+	server := *args.server
+	var dest string
+	var port int
+	if server != "" {
+		var err error
+		if protocol, dest, port, err = h.parseServerUrl(server); err != nil {
+			h.errHandler.HandleErr(err)
+			return
+		}
+	}
+	protocol, unixSocket := h.resolveProtocol(protocol, args)
+	if unixSocket {
+		connBuilder = &client.UnixConnBuilder{Path: dest}
+	} else {
+		port, err := h.resolvePort(protocol, port, args)
+		if err != nil {
+			h.errHandler.HandleErr(err)
+			return
+		}
+		connBuilder = &client.TCPConnBuilder{Host: dest, Port: port}
+	}
 	if *args.retryTimeout > 0 {
 		connBuilder = client.NewRetryConnBuilder(connBuilder, *args.retryTimeout, *args.retryInterval)
 	}

--- a/cmd/trench/main.go
+++ b/cmd/trench/main.go
@@ -57,7 +57,7 @@ var args = cmdArgs{
 	port:          kingpin.Flag("port", "Connect to the specified port.").Short('p').Int(),
 	portfile:      kingpin.Flag("port-file", "Specify port file that specifies port to connect to. Defaults to .nrepl-port.").PlaceHolder("FILE").String(),
 	protocol:      kingpin.Flag("protocol", "Use the specified protocol. Possible values: n[repl], p[repl]. Defaults to nrepl.").Default("nrepl").Short('P').Enum("n", "nrepl", "p", "prepl"),
-	server:        kingpin.Flag("server", "Connect to the specified URL (e.g. prepl://127.0.0.1:5555).").Default("127.0.0.1").Short('s').PlaceHolder("[(nrepl|prepl)://]host[:port]").String(),
+	server:        kingpin.Flag("server", "Connect to the specified URL (e.g. prepl://127.0.0.1:5555, nrepl+unix:/foo/bar.socket).").Default("127.0.0.1").Short('s').PlaceHolder("[(nrepl|prepl)://]host[:port]|nrepl+unix:/path").String(),
 	retryTimeout:  kingpin.Flag("retry-timeout", "Timeout after which retries are aborted. By default, Trenchman never retries connection.").PlaceHolder("DURATION").Duration(),
 	retryInterval: kingpin.Flag("retry-interval", "Interval between retries when connecting to the server.").Default("1s").Duration(),
 	init:          kingpin.Flag("init", "Load a file before execution.").Short('i').PlaceHolder("FILE").String(),


### PR DESCRIPTION
[nrepl/nrepl 0.9.0+](https://github.com/nrepl/nrepl/releases/tag/0.9.0) added support for connections via UNIX domain sockets.

This PR adds support for this feature. Once this is merged, Trenchman can connect to a server listening on a UNIX domain socket `/foo/bar.socket` as follows:

```console
trenchman -s nrepl+unix:/foo/bar.socket
```