### PR TITLE
`--debug` option for printing debug info

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Flags:
   -m, --main=NAMESPACE          Call the -main function for a namespace.
       --init-ns=NAMESPACE       Initialize REPL with the specified namespace. Defaults to "user".
   -C, --color=auto              When to use colors. Possible values: always, auto, none. Defaults to auto.
+      --debug                   Print debug information
       --version                 Show application version.
 
 Args:

--- a/client/client.go
+++ b/client/client.go
@@ -47,6 +47,7 @@ type (
 	OutputHandler interface {
 		Out(s string)
 		Err(s string)
+		Debug(s string)
 	}
 )
 

--- a/client/mock_server.go
+++ b/client/mock_server.go
@@ -44,6 +44,8 @@ func (m *MockServer) Err(s string) {
 	m.errs = append(m.errs, s)
 }
 
+func (m *MockServer) Debug(s string) {}
+
 func (m *MockServer) HandleErr(err error) {
 	m.handledErr = err
 }

--- a/cmd/trench/helper.go
+++ b/cmd/trench/helper.go
@@ -18,6 +18,7 @@ var unixUrlRegex = regexp.MustCompile(`^nrepl\+unix:(.+)$`)
 
 type setupHelper struct {
 	errHandler client.ErrorHandler
+	debug      bool
 }
 
 func readPortFromFile(protocol, portFile string) (int, bool, error) {
@@ -50,6 +51,7 @@ func (h setupHelper) nReplFactory(connBuilder client.ConnBuilder, initNS string)
 			InitNS:        initNS,
 			OutputHandler: outHandler,
 			ErrorHandler:  h.errHandler,
+			Debug:         h.debug,
 		})
 		if err != nil {
 			h.errHandler.HandleErr(err)
@@ -65,6 +67,7 @@ func (h setupHelper) pReplFactory(connBuilder client.ConnBuilder, initNS string)
 			InitNS:        initNS,
 			OutputHandler: outHandler,
 			ErrorHandler:  h.errHandler,
+			Debug:         h.debug,
 		})
 		if err != nil {
 			h.errHandler.HandleErr(err)

--- a/cmd/trench/main.go
+++ b/cmd/trench/main.go
@@ -34,6 +34,7 @@ type cmdArgs struct {
 	mainNS        *string
 	initNS        *string
 	colorOption   *string
+	debug         *bool
 	args          *[]string
 }
 
@@ -66,6 +67,7 @@ var args = cmdArgs{
 	mainNS:        kingpin.Flag("main", "Call the -main function for a namespace.").Short('m').PlaceHolder("NAMESPACE").String(),
 	initNS:        kingpin.Flag("init-ns", "Initialize REPL with the specified namespace. Defaults to \"user\".").PlaceHolder("NAMESPACE").String(),
 	colorOption:   kingpin.Flag("color", "When to use colors. Possible values: always, auto, none. Defaults to auto.").Default(COLOR_AUTO).Short('C').Enum(COLOR_NONE, COLOR_AUTO, COLOR_ALWAYS),
+	debug:         kingpin.Flag("debug", "Print debug information.").Bool(),
 	args:          kingpin.Arg("args", "Arguments to pass to -main. These will be ignored unless -m is specified.").Strings(),
 }
 
@@ -99,7 +101,7 @@ func main() {
 
 	printer := repl.NewPrinter(colorized(*args.colorOption))
 	errHandler := errorHandler{printer}
-	helper := setupHelper{errHandler}
+	helper := setupHelper{errHandler, *args.debug}
 	protocol, connBuilder := helper.resolveConnection(&args)
 	initFile := strings.TrimSpace(*args.init)
 	filename := strings.TrimSpace(*args.file)

--- a/nrepl/client.go
+++ b/nrepl/client.go
@@ -32,6 +32,7 @@ type (
 		OutputHandler client.OutputHandler
 		ErrorHandler  client.ErrorHandler
 		ConnBuilder   client.ConnBuilder
+		Debug         bool
 		idGenerator   func() string
 	}
 )
@@ -49,7 +50,7 @@ func NewClient(opts *Opts) (*Client, error) {
 		pending:       map[string]chan client.EvalResult{},
 		idGenerator:   opts.idGenerator,
 	}
-	conn, err := Connect(&ConnOpts{opts.ConnBuilder})
+	conn, err := Connect(&ConnOpts{opts.ConnBuilder, opts.Debug})
 	if err != nil {
 		return nil, err
 	}

--- a/nrepl/client.go
+++ b/nrepl/client.go
@@ -50,7 +50,7 @@ func NewClient(opts *Opts) (*Client, error) {
 		pending:       map[string]chan client.EvalResult{},
 		idGenerator:   opts.idGenerator,
 	}
-	conn, err := Connect(&ConnOpts{opts.ConnBuilder, opts.Debug})
+	conn, err := Connect(&ConnOpts{opts.ConnBuilder, opts.Debug, c})
 	if err != nil {
 		return nil, err
 	}
@@ -75,6 +75,10 @@ func (c *Client) Close() error {
 		return err
 	}
 	return nil
+}
+
+func (c *Client) HandleDebugMessage(s string) {
+	c.outputHandler.Debug(s)
 }
 
 func (c *Client) CurrentNS() string {

--- a/nrepl/nrepl.go
+++ b/nrepl/nrepl.go
@@ -66,11 +66,10 @@ func Connect(opts *ConnOpts) (conn *Conn, err error) {
 }
 
 func (conn *Conn) Send(req client.Request) error {
-	msg := map[string]bencode.Datum(req.(Request))
 	if conn.debug {
-		conn.debugHandler.HandleDebugMessage(fmt.Sprintf("[DEBUG:SEND] %q\n", msg))
+		conn.debugHandler.HandleDebugMessage(fmt.Sprintf("[DEBUG:SEND] %q\n", req))
 	}
-	return conn.encoder.Encode(msg)
+	return conn.encoder.Encode(map[string]bencode.Datum(req.(Request)))
 }
 
 func (conn *Conn) Recv() (client.Response, error) {

--- a/prepl/prepl.go
+++ b/prepl/prepl.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"os"
 	"strings"
 	"sync"
 
@@ -100,7 +99,7 @@ func (c *Client) Close() error {
 func (c *Client) Send(code client.Request) error {
 	msg := code.(string)
 	if c.debug {
-		fmt.Fprintf(os.Stderr, "[DEBUG:SEND] %q\n", strings.TrimSpace(msg))
+		c.outputHandler.Debug(fmt.Sprintf("[DEBUG:SEND] %q\n", strings.TrimSpace(msg)))
 	}
 	if _, err := c.writer.WriteString(msg); err != nil {
 		return err
@@ -117,7 +116,7 @@ func (c *Client) Recv() (client.Response, error) {
 		return nil, err
 	}
 	if c.debug {
-		fmt.Fprintf(os.Stderr, "[DEBUG:RECV] %s\n", resp.String())
+		c.outputHandler.Debug(fmt.Sprintf("[DEBUG:RECV] %s\n", resp.String()))
 	}
 	return client.Response(&resp), nil
 }

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -69,6 +69,10 @@ func (r *Repl) Err(s string) {
 	r.printer.With(color.FgRed).Fprint(r.err, s)
 }
 
+func (r *Repl) Debug(s string) {
+	r.printer.With(color.FgHiBlue).Fprint(r.err, s)
+}
+
 func (r *Repl) handleResults(ch <-chan client.EvalResult, hidesResult bool) {
 	for {
 		select {


### PR DESCRIPTION
Resolves #9.

After this being merged, Trenchman prints debug info (i.e. messages communicated between the client and server) with the `—debug` option:

```console
$ trench --debug
[DEBUG:SEND] map["id":"init" "op":"clone"]
[DEBUG:RECV] map["id":"init" "new-session":"cee88e31-b813-4fd4-8fc2-33fa085c7a0c" "session":"none" "status":["done"]]
[DEBUG:SEND] map["op":"describe"]
[DEBUG:RECV] map["id":"unknown" "ops":map["clone":map[] "close":map[] "complete":map[] "describe":map[] "eldoc":map[] "eval":map[] "info":map[] "load-file":map[] "lookup":map[] "ls-sessions":map[]] "session":"none" "status":["done"] "versions":map["babashka":"0.8.156" "babashka.nrepl":"0.0.6-SNAPSHOT"]]
user=> (map inc [1 2 3])
[DEBUG:SEND] map["code":"(map inc [1 2 3])" "id":"a524995d-a048-4b43-869a-db23185c90c4" "ns":"user" "op":"eval" "session":"cee88e31-b813-4fd4-8fc2-33fa085c7a0c"]
[DEBUG:RECV] map["id":"a524995d-a048-4b43-869a-db23185c90c4" "ns":"user" "session":"cee88e31-b813-4fd4-8fc2-33fa085c7a0c" "value":"(2 3 4)"]
[DEBUG:RECV] map["id":"a524995d-a048-4b43-869a-db23185c90c4" "session":"cee88e31-b813-4fd4-8fc2-33fa085c7a0c" "status":["done"]]
(2 3 4)
user=>
```